### PR TITLE
Fixing Bug #13

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+poetry.toml
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netbox-physical-clusters"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Pat McLean <patrick.mclean@sap.com>", "The Fail Druid <faildruid@ahra.ie"]
 readme = "README.md"
 keywords = ["Netbox", "netbox", "plugin"]


### PR DESCRIPTION
Local development files were conflicting with the development container. 

A `.dockerignore` file has been created and the local development files have been added to the file.
- `poetry.toml` which was being used for local development was conflicting with the poetry config in the `Dockerfile`
- `.venv` the local virtualenvironment has also been excluded for clarity